### PR TITLE
feat: ust-web-signer (LIGHT browser signer) + 'Make it UST' extension

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -18,20 +18,23 @@ It is the reference consumer of [`ust-web-signer`](../packages/ust-web-signer) (
 ```
 Source: https://example.com/article  (claimed by sender — NOT verified)
 Verified by UST (LIGHT): the exact bytes below · the signing key · the capture time. The source URL is not part of the proof.
-———UST———
-{"ust":"1.0","state":{…},"sig":{…}}
+———UST(base64)———
+eyJ1c3QiOiIxLjAiLCJzdGF0ZSI6eyJpZCI6ey…
 ```
 
-The line before `———UST———` is a **plain-text, unsigned** note for humans — the page URL is the sender's *claim*,
-deliberately kept **outside** the signature. Everything after `———UST———` is the signed document.
+The lines before `———UST(base64)———` are a **plain-text, unsigned** note for humans — the page URL is the
+sender's *claim*, deliberately kept **outside** the signature. The token after the delimiter is the signed
+document, **base64-encoded** so its exact bytes survive any paste channel (chat / terminal / apps often normalize
+whitespace + unicode inside raw JSON, which would silently break the signature — a real capture failed exactly
+this way).
 
 ## Verify a copied transcript
 
-Take the JSON after `———UST———` and verify it with the reference verifier:
+Take the base64 after `———UST(base64)———`, decode it, and verify with the reference verifier:
 
 ```
 npm i ust-protocol@rc
-node -e "import('ust-protocol').then(P => console.log(P.verify(JSON.parse(process.argv[1]), {context:'data'})))" '<paste the UST json>'
+node -e "import('ust-protocol').then(P=>console.log(P.verify(JSON.parse(Buffer.from(process.argv[1],'base64').toString('utf8')),{context:'data'})))" '<paste the base64>'
 ```
 
 Expected: `result: "VALID:LIGHT"`, `identity.strength: "self-asserted"`, `publisher_claimed` = your `key_id`

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,49 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Make it UST — test browser extension
+
+A minimal Manifest V3 extension that packages the **LIGHT tier** of [UST](https://github.com/thelabmd/UST) into
+one gesture: **select text → right-click → "Make it UST" → a signed transcript is on your clipboard.**
+
+It is the reference consumer of [`ust-web-signer`](../packages/ust-web-signer) (bundled in `lib/`).
+
+## Load it (unpacked)
+
+1. Chrome → `chrome://extensions` → enable **Developer mode**.
+2. **Load unpacked** → select this `extension/` folder.
+3. On first use it generates a **non-extractable** Ed25519 key (your identity, `key_id`), stored in IndexedDB and
+   never exported. Click the toolbar icon to see your `key_id`.
+
+## What ends up on your clipboard
+
+```
+Source: https://example.com/article  (claimed by sender — NOT verified)
+Verified by UST (LIGHT): the exact bytes below · the signing key · the capture time. The source URL is not part of the proof.
+———UST———
+{"ust":"1.0","state":{…},"sig":{…}}
+```
+
+The line before `———UST———` is a **plain-text, unsigned** note for humans — the page URL is the sender's *claim*,
+deliberately kept **outside** the signature. Everything after `———UST———` is the signed document.
+
+## Verify a copied transcript
+
+Take the JSON after `———UST———` and verify it with the reference verifier:
+
+```
+npm i ust-protocol@rc
+node -e "import('ust-protocol').then(P => console.log(P.verify(JSON.parse(process.argv[1]), {context:'data'})))" '<paste the UST json>'
+```
+
+Expected: `result: "VALID:LIGHT"`, `identity.strength: "self-asserted"`, `publisher_claimed` = your `key_id`
+(the identity is your **key**, self-certifying — no name is claimed). Edit a byte of the text and it goes
+`INVALID`.
+
+## What this proves — and what it doesn't
+
+- **Proves:** these exact bytes were signed by this key at this claimed time. Tamper-evident, verifiable offline.
+- **Does NOT prove:** that you are a specific person or domain (that is **HIGH** tier — name authority), or that
+  the page really served those bytes (an unverifiable URL; a real proof would need the site to sign, a witness, or
+  a TLS-notarization layer). The extension says exactly this, in plain language, so no one over-reads a LIGHT
+  capture.
+
+*Test extension — no key backup, per-browser identity, best-effort clipboard. Not production.*

--- a/extension/background.js
+++ b/extension/background.js
@@ -32,14 +32,22 @@ async function getSigner() {
   return W.signerFromKeys(kp.privateKey, kp.publicKey);
 }
 
+// UTF-8-safe base64 — the signed UST rides as base64 (pure ASCII) so it survives ANY paste channel. Raw JSON in
+// the clipboard gets whitespace/unicode-normalized by chat/terminal/some apps → the signature breaks (a real
+// capture failed exactly this way). base64 preserves the EXACT bytes end-to-end.
+function b64utf8(str) {
+  const bytes = new TextEncoder().encode(str);
+  let bin = ''; for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
 // ── the clipboard blob: honest UNSIGNED preamble (positive framing of what IS proven) + the signed UST (l43v) ──
 function clipboardBlob(doc, pageUrl) {
   const src = pageUrl ? 'Source: ' + pageUrl + '  (claimed by sender — NOT verified)\n' : '';
   return src +
     'Verified by UST (LIGHT): the exact bytes below · the signing key · the capture time. ' +
     'The source URL is not part of the proof.\n' +
-    '———UST———\n' +
-    JSON.stringify(doc);
+    '———UST(base64)———\n' +
+    b64utf8(JSON.stringify(doc));
 }
 
 // ── write to the clipboard by injecting into the active tab (activeTab is granted by the context-menu gesture) ──

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// "Make it UST" — MV3 service worker. Select text → context menu → sign a LIGHT UST with the browser's own key →
+// copy an honest blob to the clipboard. The private key is generated NON-EXTRACTABLE and persisted in IndexedDB;
+// it never leaves WebCrypto. Per the LIGHT-honesty rule, only the captured bytes + time are signed — the page URL
+// rides ALONG as a plain-text, explicitly-UNVERIFIED note, OUTSIDE the signed UST.
+import * as W from './lib/ust-web-signer.mjs';
+
+const MENU_ID = 'make-it-ust';
+
+// ── persistent, non-extractable Ed25519 identity in IndexedDB (CryptoKeys are structured-cloneable) ──
+function openDB() {
+  return new Promise((res, rej) => {
+    const r = indexedDB.open('ust-signer', 1);
+    r.onupgradeneeded = () => r.result.createObjectStore('keys');
+    r.onsuccess = () => res(r.result);
+    r.onerror = () => rej(r.error);
+  });
+}
+async function idbGet(key) {
+  const db = await openDB();
+  return new Promise((res) => { const t = db.transaction('keys').objectStore('keys').get(key); t.onsuccess = () => res(t.result ?? null); t.onerror = () => res(null); });
+}
+async function idbPut(key, val) {
+  const db = await openDB();
+  return new Promise((res, rej) => { const t = db.transaction('keys', 'readwrite').objectStore('keys').put(val, key); t.onsuccess = () => res(); t.onerror = () => rej(t.error); });
+}
+async function getSigner() {
+  const stored = await idbGet('ed25519');
+  if (stored?.privateKey && stored?.publicKey) return W.signerFromKeys(stored.privateKey, stored.publicKey);
+  const kp = await crypto.subtle.generateKey({ name: 'Ed25519' }, false, ['sign', 'verify']);   // NON-EXTRACTABLE
+  await idbPut('ed25519', { privateKey: kp.privateKey, publicKey: kp.publicKey });
+  return W.signerFromKeys(kp.privateKey, kp.publicKey);
+}
+
+// ── the clipboard blob: honest UNSIGNED preamble (positive framing of what IS proven) + the signed UST (l43v) ──
+function clipboardBlob(doc, pageUrl) {
+  const src = pageUrl ? 'Source: ' + pageUrl + '  (claimed by sender — NOT verified)\n' : '';
+  return src +
+    'Verified by UST (LIGHT): the exact bytes below · the signing key · the capture time. ' +
+    'The source URL is not part of the proof.\n' +
+    '———UST———\n' +
+    JSON.stringify(doc);
+}
+
+// ── write to the clipboard by injecting into the active tab (activeTab is granted by the context-menu gesture) ──
+async function copyToTab(tabId, text) {
+  await chrome.scripting.executeScript({
+    target: { tabId },
+    func: (t) => {
+      function fallback() {
+        const ta = document.createElement('textarea');
+        ta.value = t; ta.style.position = 'fixed'; ta.style.opacity = '0';
+        document.body.appendChild(ta); ta.focus(); ta.select();
+        try { document.execCommand('copy'); } finally { ta.remove(); }
+      }
+      if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(t).catch(fallback);
+      else fallback();
+    },
+    args: [text],
+  });
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({ id: MENU_ID, title: 'Make it UST', contexts: ['selection'] });
+  getSigner();                                             // warm (generate) the identity on install
+});
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId !== MENU_ID || !info.selectionText || !tab?.id) return;
+  try {
+    const signer = await getSigner();
+    const { ust_id, time } = W.nowFrame();
+    const doc = await W.signObservation(signer, {
+      ust_id, time,
+      data: { capture: { kind: 'captured', value: { text: info.selectionText.normalize('NFC') } } },   // values MUST be NFC (§6)
+    });
+    await copyToTab(tab.id, clipboardBlob(doc, info.pageUrl));
+    chrome.action.setBadgeText({ text: '✓', tabId: tab.id });
+    chrome.action.setBadgeBackgroundColor({ color: '#1a7f37', tabId: tab.id });
+    setTimeout(() => chrome.action.setBadgeText({ text: '', tabId: tab.id }), 1500);
+  } catch (e) {
+    console.error('Make it UST failed:', e);
+    chrome.action.setBadgeText({ text: '!', tabId: tab.id });
+  }
+});

--- a/extension/lib/ust-web-signer.mjs
+++ b/extension/lib/ust-web-signer.mjs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// ust-web-signer — WebCrypto Ed25519 SIGNER + producer for UST 1.0. Browser + Workers + Node (global crypto.subtle).
+// The canon/hash/preimage helpers are BYTE-IDENTICAL to ust-protocol (same spec §6/§7/§4.4), so documents this
+// produces verify as VALID under ust-protocol / the clean-room verifier. The PRIVATE KEY never leaves WebCrypto:
+// generate it NON-EXTRACTABLE and persist the CryptoKey object (structured-cloneable) in IndexedDB.
+//
+// LIGHT-tier honesty (see the extension): sign ONLY what the signature guarantees — the exact bytes, the key, and
+// the claimed time. Identity is the KEY, not a claimed name: `domain_shard` is set to the signer's own key_id
+// (self-certifying). Do NOT put an unverifiable page URL or a claimed domain inside the signed state.
+
+const te = (s) => new TextEncoder().encode(s);
+const hex = (buf) => [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+const concat = (a, b) => { const o = new Uint8Array(a.length + b.length); o.set(a, 0); o.set(b, a.length); return o; };
+const b64urlToBytes = (s) => Uint8Array.from(atob(String(s).replace(/-/g, '+').replace(/_/g, '/')), (c) => c.charCodeAt(0));
+const bytesToB64url = (bytes) => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+// ─── §6 canon (JCS tightened): string-only leaves, NFC (names + values), sorted+unique keys. Throws E-CANON. ───
+export function canon(v) {
+  if (v === null || typeof v === 'number' || typeof v === 'boolean') throw { code: 'E-CANON', detail: 'non-string leaf' };
+  if (typeof v === 'string') { if (v.normalize('NFC') !== v) throw { code: 'E-CANON', detail: 'non-NFC' }; return JSON.stringify(v); }
+  if (Array.isArray(v)) return '[' + v.map(canon).join(',') + ']';
+  const k = Object.keys(v); if (new Set(k).size !== k.length) throw { code: 'E-CANON', detail: 'dup key' };
+  for (const x of k) if (x.normalize('NFC') !== x) throw { code: 'E-CANON', detail: 'non-NFC key' };
+  return '{' + k.sort().map((x) => JSON.stringify(x) + ':' + canon(v[x])).join(',') + '}';
+}
+// ─── §7 domain-separated hash: "sha256:" + hex(SHA256(ascii(tag) || 0x00 || body)) ───
+async function digest(tag, body) { return 'sha256:' + hex(await crypto.subtle.digest('SHA-256', concat(concat(te(tag), new Uint8Array([0])), body))); }
+export const H = (tag, str) => digest(tag, te(str));
+export const Hbytes = (tag, bytes) => digest(tag, bytes);
+export const keyId = (pubB64url) => Hbytes('ust:keylog', b64urlToBytes(pubB64url));   // §12.2 over RAW pubkey bytes
+export async function partitionHash({ domain_shard, ust_id, name, value, commit }) {
+  if (commit !== undefined) return H('ust:shard', commit);                             // §10 private
+  return H('ust:shard', canon({ domain_shard, ust_id, partition: name, value }));      // uniform preimage (name is a VALUE)
+}
+export const contentHash = (doc) => H('ust:state', canon({ ust: doc.ust, state: doc.state }));
+export const signedContent = (doc) => canon({ ust: doc.ust, state: doc.state });
+
+// ─── producer: assemble a State with per-partition `hashes` auto-computed (§4.4) ───
+export async function buildState(id, time, data) {
+  const hashes = {};
+  for (const [name, part] of Object.entries(data)) {
+    hashes[name] = part.commit !== undefined
+      ? await partitionHash({ commit: part.commit })
+      : await partitionHash({ domain_shard: id.domain_shard, ust_id: id.ust_id, name, value: part.value });
+  }
+  return { id, time, data, hashes };
+}
+
+// ─── the SIGNER — the piece ust-protocol deliberately omits (a key never enters the verifier lib) ───
+// Generate an Ed25519 keypair. `extractable:false` keeps the private key inside WebCrypto forever; the CryptoKey
+// object itself is structured-cloneable, so persist it in IndexedDB to reuse the same identity across sessions.
+export async function generateSigner({ extractable = false } = {}) {
+  const kp = await crypto.subtle.generateKey({ name: 'Ed25519' }, extractable, ['sign', 'verify']);
+  return signerFromKeys(kp.privateKey, kp.publicKey);
+}
+export async function signerFromKeys(privateKey, publicKey) {
+  const raw = new Uint8Array(await crypto.subtle.exportKey('raw', publicKey));          // 32 raw pubkey bytes (always exportable)
+  const pub = bytesToB64url(raw);
+  return { privateKey, publicKey, pub, key_id: await keyId(pub) };
+}
+
+// §7 seal — sign canon({ust,state}) with the WebCrypto private key. Ed25519 signing is always canonical-S, so the
+// strict verifier accepts it. Returns the full { ust, state, sig } document.
+export async function seal(state, signer) {
+  const input = signedContent({ ust: '1.0', state });
+  const sigBuf = await crypto.subtle.sign({ name: 'Ed25519' }, signer.privateKey, te(input));
+  const sig = bytesToB64url(new Uint8Array(sigBuf));
+  return { ust: '1.0', state, sig: { alg: 'Ed25519', key_id: state.id.key_id, pub: signer.pub, sig } };
+}
+
+// ─── convenience: build + sign a LIGHT observation. Identity = the KEY (domain_shard := key_id, self-certifying);
+//     no claimed name, no unverifiable URL in the signed state. `data` maps partition-name → { value } (captured). ───
+export async function signObservation(signer, { ust_id, time, data }) {
+  const id = { domain_shard: signer.key_id, ust_id, key_id: signer.key_id, class: 'observation' };
+  const state = await buildState(id, time, data);
+  return seal(state, signer);
+}
+
+// helper: current UTC hour → ust_id + a matching time window (valid_from = generated_at = now, valid_to = +1h).
+export function nowFrame(date = new Date()) {
+  const iso = date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const to = new Date(date.getTime() + 3_600_000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const ust_id = 'ust:' + iso.slice(0, 10).replace(/-/g, '') + '.' + iso.slice(11, 13);
+  return { ust_id, time: { generated_at: iso, valid_from: iso, valid_to: to } };
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,9 @@
+{
+  "manifest_version": 3,
+  "name": "Make it UST",
+  "version": "0.1.0",
+  "description": "Sign selected text as a UST (Universal State Transcript). LIGHT tier: proves the exact bytes, your key, and the time — not who you are or where it came from.",
+  "permissions": ["contextMenus", "scripting", "activeTab"],
+  "background": { "service_worker": "background.js", "type": "module" },
+  "action": { "default_popup": "popup.html", "default_title": "Make it UST" }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { font: 13px/1.5 system-ui, sans-serif; width: 320px; margin: 0; padding: 14px; color: #111; }
+    h1 { font-size: 14px; margin: 0 0 8px; }
+    .k { font: 11px/1.4 ui-monospace, monospace; word-break: break-all; background: #f3f3f3; padding: 6px 8px; border-radius: 6px; }
+    .muted { color: #666; margin-top: 10px; }
+    .lbl { color: #666; margin: 10px 0 3px; }
+    b { color: #1a7f37; }
+  </style>
+</head>
+<body>
+  <h1>Make it UST</h1>
+  <div class="lbl">Your identity (key_id):</div>
+  <div class="k" id="id">…</div>
+  <div class="lbl">Public key:</div>
+  <div class="k" id="pub">…</div>
+  <p class="muted">Select text on any page → right-click → <b>Make it UST</b>. A signed transcript is copied to your
+    clipboard. It proves the <b>exact bytes</b>, your <b>key</b>, and the <b>time</b> — <i>not</i> who you are or where
+    it came from. Your private key stays in this browser and is never exported.</p>
+</body>
+<script type="module" src="popup.js"></script>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as W from './lib/ust-web-signer.mjs';
+
+function openDB() {
+  return new Promise((res, rej) => {
+    const r = indexedDB.open('ust-signer', 1);
+    r.onupgradeneeded = () => r.result.createObjectStore('keys');
+    r.onsuccess = () => res(r.result);
+    r.onerror = () => rej(r.error);
+  });
+}
+async function idbGet(key) {
+  const db = await openDB();
+  return new Promise((res) => { const t = db.transaction('keys').objectStore('keys').get(key); t.onsuccess = () => res(t.result ?? null); t.onerror = () => res(null); });
+}
+
+(async () => {
+  const stored = await idbGet('ed25519');
+  if (!stored?.publicKey) {
+    document.getElementById('id').textContent = 'no identity yet — use "Make it UST" once to create it';
+    document.getElementById('pub').textContent = '—';
+    return;
+  }
+  const s = await W.signerFromKeys(stored.privateKey, stored.publicKey);
+  document.getElementById('id').textContent = s.key_id;
+  document.getElementById('pub').textContent = s.pub;
+})();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "Apache-2.0",
   "workspaces": [
     "packages/ust-protocol",
-    "packages/ust-mcp"
+    "packages/ust-mcp",
+    "packages/ust-web-signer"
   ],
   "scripts": {
     "test": "node packages/ust-protocol/conformance.mjs"

--- a/packages/ust-web-signer/LICENSE
+++ b/packages/ust-web-signer/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ust-web-signer/README.md
+++ b/packages/ust-web-signer/README.md
@@ -1,0 +1,39 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# ust-web-signer
+
+The **browser-side signer** for [UST (Universal State Transcript)](https://github.com/thelabmd/UST). It is the
+one piece [`ust-protocol`](https://www.npmjs.com/package/ust-protocol) deliberately leaves out: a **private key
+never enters the verifier library**. This package generates an Ed25519 key with WebCrypto, signs, and produces the
+full `{ ust, state, sig }` document. Its `canon`/hash/preimage code is byte-identical to `ust-protocol`, so what
+it signs verifies **VALID** there.
+
+Runs in browsers, Web Workers / service workers, and Node ≥ 20 (global `crypto.subtle`). Zero dependencies.
+
+```js
+import { generateSigner, signObservation, nowFrame } from 'ust-web-signer';
+
+const signer = await generateSigner();                 // Ed25519, private key NON-EXTRACTABLE (stays in WebCrypto)
+const { ust_id, time } = nowFrame();                   // current UTC hour
+const doc = await signObservation(signer, {
+  ust_id, time,
+  data: { capture: { kind: 'captured', value: { text: 'the exact bytes I saw' } } },
+});
+// doc verifies as VALID:LIGHT under ust-protocol. doc.sig.pub is the public key; signer.key_id is the identity.
+```
+
+## LIGHT-tier honesty (read this)
+
+At the LIGHT tier a signature proves exactly three things: **the exact bytes**, **the signing key**, and **the
+claimed time**. It does **not** prove *who you are* (a human/domain name is a HIGH-tier claim) or *where the bytes
+came from* (an unverifiable page URL is the signer's claim, not a proof).
+
+So this signer, by design:
+
+- sets `domain_shard` to the signer's own **`key_id`** — identity is the **key**, self-certifying. It never puts a
+  claimed domain name into the signed state.
+- signs **only** the captured value + time. Do **not** put a page URL, origin, or claimed source inside the signed
+  `state` — a consumer would read the signature as proving it. Keep such context **outside** the signed document
+  (e.g. a plain-text, explicitly-unverified note in the clipboard next to the UST).
+
+Persist the identity by storing the `CryptoKey` (structured-cloneable) in **IndexedDB**; a non-extractable key
+cannot be exported, which is the point.

--- a/packages/ust-web-signer/index.mjs
+++ b/packages/ust-web-signer/index.mjs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// ust-web-signer — WebCrypto Ed25519 SIGNER + producer for UST 1.0. Browser + Workers + Node (global crypto.subtle).
+// The canon/hash/preimage helpers are BYTE-IDENTICAL to ust-protocol (same spec §6/§7/§4.4), so documents this
+// produces verify as VALID under ust-protocol / the clean-room verifier. The PRIVATE KEY never leaves WebCrypto:
+// generate it NON-EXTRACTABLE and persist the CryptoKey object (structured-cloneable) in IndexedDB.
+//
+// LIGHT-tier honesty (see the extension): sign ONLY what the signature guarantees — the exact bytes, the key, and
+// the claimed time. Identity is the KEY, not a claimed name: `domain_shard` is set to the signer's own key_id
+// (self-certifying). Do NOT put an unverifiable page URL or a claimed domain inside the signed state.
+
+const te = (s) => new TextEncoder().encode(s);
+const hex = (buf) => [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+const concat = (a, b) => { const o = new Uint8Array(a.length + b.length); o.set(a, 0); o.set(b, a.length); return o; };
+const b64urlToBytes = (s) => Uint8Array.from(atob(String(s).replace(/-/g, '+').replace(/_/g, '/')), (c) => c.charCodeAt(0));
+const bytesToB64url = (bytes) => btoa(String.fromCharCode(...bytes)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+// ─── §6 canon (JCS tightened): string-only leaves, NFC (names + values), sorted+unique keys. Throws E-CANON. ───
+export function canon(v) {
+  if (v === null || typeof v === 'number' || typeof v === 'boolean') throw { code: 'E-CANON', detail: 'non-string leaf' };
+  if (typeof v === 'string') { if (v.normalize('NFC') !== v) throw { code: 'E-CANON', detail: 'non-NFC' }; return JSON.stringify(v); }
+  if (Array.isArray(v)) return '[' + v.map(canon).join(',') + ']';
+  const k = Object.keys(v); if (new Set(k).size !== k.length) throw { code: 'E-CANON', detail: 'dup key' };
+  for (const x of k) if (x.normalize('NFC') !== x) throw { code: 'E-CANON', detail: 'non-NFC key' };
+  return '{' + k.sort().map((x) => JSON.stringify(x) + ':' + canon(v[x])).join(',') + '}';
+}
+// ─── §7 domain-separated hash: "sha256:" + hex(SHA256(ascii(tag) || 0x00 || body)) ───
+async function digest(tag, body) { return 'sha256:' + hex(await crypto.subtle.digest('SHA-256', concat(concat(te(tag), new Uint8Array([0])), body))); }
+export const H = (tag, str) => digest(tag, te(str));
+export const Hbytes = (tag, bytes) => digest(tag, bytes);
+export const keyId = (pubB64url) => Hbytes('ust:keylog', b64urlToBytes(pubB64url));   // §12.2 over RAW pubkey bytes
+export async function partitionHash({ domain_shard, ust_id, name, value, commit }) {
+  if (commit !== undefined) return H('ust:shard', commit);                             // §10 private
+  return H('ust:shard', canon({ domain_shard, ust_id, partition: name, value }));      // uniform preimage (name is a VALUE)
+}
+export const contentHash = (doc) => H('ust:state', canon({ ust: doc.ust, state: doc.state }));
+export const signedContent = (doc) => canon({ ust: doc.ust, state: doc.state });
+
+// ─── producer: assemble a State with per-partition `hashes` auto-computed (§4.4) ───
+export async function buildState(id, time, data) {
+  const hashes = {};
+  for (const [name, part] of Object.entries(data)) {
+    hashes[name] = part.commit !== undefined
+      ? await partitionHash({ commit: part.commit })
+      : await partitionHash({ domain_shard: id.domain_shard, ust_id: id.ust_id, name, value: part.value });
+  }
+  return { id, time, data, hashes };
+}
+
+// ─── the SIGNER — the piece ust-protocol deliberately omits (a key never enters the verifier lib) ───
+// Generate an Ed25519 keypair. `extractable:false` keeps the private key inside WebCrypto forever; the CryptoKey
+// object itself is structured-cloneable, so persist it in IndexedDB to reuse the same identity across sessions.
+export async function generateSigner({ extractable = false } = {}) {
+  const kp = await crypto.subtle.generateKey({ name: 'Ed25519' }, extractable, ['sign', 'verify']);
+  return signerFromKeys(kp.privateKey, kp.publicKey);
+}
+export async function signerFromKeys(privateKey, publicKey) {
+  const raw = new Uint8Array(await crypto.subtle.exportKey('raw', publicKey));          // 32 raw pubkey bytes (always exportable)
+  const pub = bytesToB64url(raw);
+  return { privateKey, publicKey, pub, key_id: await keyId(pub) };
+}
+
+// §7 seal — sign canon({ust,state}) with the WebCrypto private key. Ed25519 signing is always canonical-S, so the
+// strict verifier accepts it. Returns the full { ust, state, sig } document.
+export async function seal(state, signer) {
+  const input = signedContent({ ust: '1.0', state });
+  const sigBuf = await crypto.subtle.sign({ name: 'Ed25519' }, signer.privateKey, te(input));
+  const sig = bytesToB64url(new Uint8Array(sigBuf));
+  return { ust: '1.0', state, sig: { alg: 'Ed25519', key_id: state.id.key_id, pub: signer.pub, sig } };
+}
+
+// ─── convenience: build + sign a LIGHT observation. Identity = the KEY (domain_shard := key_id, self-certifying);
+//     no claimed name, no unverifiable URL in the signed state. `data` maps partition-name → { value } (captured). ───
+export async function signObservation(signer, { ust_id, time, data }) {
+  const id = { domain_shard: signer.key_id, ust_id, key_id: signer.key_id, class: 'observation' };
+  const state = await buildState(id, time, data);
+  return seal(state, signer);
+}
+
+// helper: current UTC hour → ust_id + a matching time window (valid_from = generated_at = now, valid_to = +1h).
+export function nowFrame(date = new Date()) {
+  const iso = date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const to = new Date(date.getTime() + 3_600_000).toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const ust_id = 'ust:' + iso.slice(0, 10).replace(/-/g, '') + '.' + iso.slice(11, 13);
+  return { ust_id, time: { generated_at: iso, valid_from: iso, valid_to: to } };
+}

--- a/packages/ust-web-signer/package.json
+++ b/packages/ust-web-signer/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "ust-web-signer",
+  "version": "1.0.0-rc.1",
+  "description": "WebCrypto Ed25519 signer + producer for UST (Universal State Transcript) 1.0 — the browser-side piece that ust-protocol deliberately omits (a private key never enters the verifier). Byte-compatible; produces documents that verify VALID under ust-protocol.",
+  "author": "THE LAB (https://thelab.md)",
+  "type": "module",
+  "main": "./index.mjs",
+  "exports": {
+    ".": "./index.mjs"
+  },
+  "files": [
+    "index.mjs",
+    "LICENSE",
+    "README.md"
+  ],
+  "keywords": [
+    "ust",
+    "webcrypto",
+    "ed25519",
+    "signing",
+    "browser",
+    "trust-infrastructure"
+  ],
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thelabmd/UST.git",
+    "directory": "packages/ust-web-signer"
+  },
+  "homepage": "https://github.com/thelabmd/UST/tree/main/packages/ust-web-signer#readme",
+  "bugs": "https://github.com/thelabmd/UST/issues"
+}

--- a/packages/ust-web-signer/test.mjs
+++ b/packages/ust-web-signer/test.mjs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Cross-compat proof: a document SIGNED by ust-web-signer (WebCrypto) must verify VALID under ust-protocol
+// (node:crypto) — two independent implementations agreeing that the bytes/preimage/signature line up.
+import * as W from './index.mjs';
+import * as P from '../ust-protocol/index.mjs';
+
+let pass = 0, fail = 0;
+const check = (id, ok, d) => { if (ok) pass++; else { fail++; console.log('  ✗ ' + id + (d ? ' — ' + d : '')); } };
+
+const signer = await W.generateSigner({ extractable: false });
+check('key_id derives the same on both sides', signer.key_id === P.keyId(signer.pub), signer.key_id + ' vs ' + P.keyId(signer.pub));
+
+const { ust_id, time } = W.nowFrame(new Date('2026-07-08T12:34:56Z'));
+const doc = await W.signObservation(signer, {
+  ust_id, time,
+  data: { capture: { kind: 'captured', value: { text: 'the exact bytes I saw — café ☕' } } },
+});
+
+// content_hash agrees across impls (byte-identical canon + preimage)
+check('content_hash agrees (web-signer vs ust-protocol)', (await W.contentHash(doc)) === P.contentHash(doc));
+
+// ust-protocol (the independent verifier) accepts the web-signed doc
+const r = P.verify(doc, { context: 'data' });
+check('ust-protocol verify → VALID:LIGHT', r.result === 'VALID:LIGHT', 'got ' + r.result);
+check('identity is the KEY (self-certifying, no claimed name)', r.publisher_claimed === signer.key_id && r.publisher === undefined);
+check('domain_shard == key_id (self-certifying)', doc.state.id.domain_shard === signer.key_id);
+check('no url/origin/source leaked into signed state', JSON.stringify(doc.state.data).match(/https?:|origin|source|url/i) === null);
+
+// tamper → INVALID (integrity holds)
+const bad = JSON.parse(JSON.stringify(doc)); bad.state.data.capture.value.text = 'edited';
+check('tampered text → INVALID', P.verify(bad, { context: 'data' }).result === 'INVALID');
+
+console.log('\n════════════════════════════════════════════');
+console.log('  ust-web-signer × ust-protocol   PASS ' + pass + '   FAIL ' + fail);
+console.log(fail ? '' : '  ✓ web-signed documents verify under the independent Node verifier');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Packages the **LIGHT tier** into a gesture — the first Вася-scale UST product. Two parts: a reusable browser signer package, and a demo extension that consumes it. **No normative protocol changes**; `conformance 56/0`, cross-compat `7/0`.

## `packages/ust-web-signer/` (new public package)
The browser-side **Ed25519 signer** that `ust-protocol` deliberately omits — *a private key never enters the verifier lib*. WebCrypto only, zero deps, Node ≥20 / browsers / Workers.

- `canon` / `H` / `keyId` / `partitionHash` / `contentHash` are **byte-identical** to `ust-protocol` → what it signs verifies `VALID:LIGHT` there. Proven by `test.mjs` (**7/0**): sign with WebCrypto → verify with node:crypto.
- **LIGHT-honesty by construction** (per bd `l43v`): identity **is the key** — `domain_shard` := the signer's own `key_id` (self-certifying, no claimed name). Signs **only** captured bytes + time. Never puts a URL/origin/claimed source into the signed state.
- Private key generated **non-extractable**; persist the `CryptoKey` in IndexedDB.

## `extension/` (Manifest V3 demo)
Select text → right-click **Make it UST** → signed transcript on the clipboard.

- Key generated non-extractable, stored in IndexedDB, never exported. Popup shows your `key_id`.
- Clipboard blob = **honest unsigned preamble** (page URL as the sender's *explicitly-unverified* claim) + the signed UST after a `———UST———` delimiter. The URL rides **outside** the signature, so no one over-reads a LIGHT capture (bd `l43v` decision).
- Positive framing: states what IS proven (bytes + key + time) and what is not (who you are = HIGH; where it came from = a URL/witness/TLS-notary layer).

## Files
- `packages/ust-web-signer/`: `index.mjs`, `package.json`, `README.md`, `test.mjs`, `LICENSE`; added to root `workspaces`.
- `extension/`: `background.js`, `manifest.json`, `popup.html`, `popup.js`, `lib/ust-web-signer.mjs` (byte-copy of the signer — MV3 can't npm-install), `README.md`.

## Not done here (follow-ups)
- Publishing `ust-web-signer@1.0.0-rc.1` to npm (new public package — needs an explicit go).
- Key backup / cross-device identity (test extension uses a per-browser non-extractable key).