### PR TITLE
feat: machine-first verify header (PURL) + findable web verifier (GitHub Pages)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Verify a UST — Universal State Transcript</title>
+<meta name="description" content="Paste a UST 1.0 transcript. The canonical reference verifier runs in your browser — nothing is uploaded. Returns VALID:LIGHT/HIGH/TOP, INVALID, or INDETERMINATE.">
+<style>
+  :root { --bg:#f7f6f2; --fg:#141414; --dim:#6b6b6b; --line:#dcdad2; --ok:#0a7d34; --bad:#b3261e; --wait:#8a6d00; --box:#fffffe; }
+  @media (prefers-color-scheme: dark) { :root { --bg:#12130f; --fg:#e9e8e2; --dim:#8f8f86; --line:#2b2c26; --ok:#5fd68a; --bad:#ff6b60; --wait:#e3c04a; --box:#191a15; } }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg); font:15px/1.55 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+  main { max-width:760px; margin:0 auto; padding:40px 20px 80px; }
+  h1 { font-size:19px; font-weight:600; margin:0 0 4px; letter-spacing:-0.01em; }
+  .sub { color:var(--dim); margin:0 0 24px; font-size:13px; }
+  .sub a { color:var(--dim); }
+  textarea { width:100%; min-height:150px; resize:vertical; background:var(--box); color:var(--fg); border:1px solid var(--line); border-radius:8px; padding:12px 14px; font:13px/1.5 inherit; }
+  textarea:focus { outline:none; border-color:var(--dim); }
+  .row { display:flex; gap:10px; align-items:center; margin:12px 0 0; }
+  button { background:var(--fg); color:var(--bg); border:0; border-radius:7px; padding:9px 16px; font:600 13px/1 inherit; cursor:pointer; }
+  button.ghost { background:transparent; color:var(--dim); border:1px solid var(--line); }
+  #out { margin-top:26px; }
+  .verdict { font-size:22px; font-weight:700; letter-spacing:-0.01em; display:flex; align-items:center; gap:10px; }
+  .dot { width:11px; height:11px; border-radius:50%; flex:0 0 auto; }
+  .ok { color:var(--ok); } .ok .dot { background:var(--ok); }
+  .bad { color:var(--bad); } .bad .dot { background:var(--bad); }
+  .wait { color:var(--wait); } .wait .dot { background:var(--wait); }
+  .card { background:var(--box); border:1px solid var(--line); border-radius:8px; padding:16px 18px; margin-top:16px; }
+  .card h2 { font-size:12px; font-weight:600; text-transform:uppercase; letter-spacing:0.06em; color:var(--dim); margin:0 0 12px; }
+  .kv { display:grid; grid-template-columns:120px 1fr; gap:6px 14px; font-size:13px; }
+  .kv dt { color:var(--dim); }
+  .kv dd { margin:0; word-break:break-all; }
+  .content { white-space:pre-wrap; word-break:break-word; background:var(--bg); border:1px solid var(--line); border-radius:6px; padding:10px 12px; font-size:13px; margin-top:2px; }
+  .note { color:var(--dim); font-size:12.5px; line-height:1.5; margin-top:14px; }
+  .note b { color:var(--fg); font-weight:600; }
+  .err { color:var(--bad); font-size:13px; margin-top:8px; }
+  code { background:var(--bg); border:1px solid var(--line); border-radius:4px; padding:1px 5px; font-size:12px; }
+  footer { color:var(--dim); font-size:12px; margin-top:40px; border-top:1px solid var(--line); padding-top:16px; }
+  footer a { color:var(--dim); }
+</style>
+</head>
+<body>
+<main>
+  <h1>Verify a UST</h1>
+  <p class="sub">Paste a UST 1.0 transcript (the whole clipboard blob, the base64, or the raw JSON). The
+  <b>canonical reference verifier</b> runs <b>in your browser</b> — nothing is uploaded, no server sees it.</p>
+
+  <textarea id="in" spellcheck="false" placeholder="UST/1.0; ref=pkg:npm/ust-protocol; …&#10;———UST(base64)———&#10;eyJ1c3QiOiIxLjAi…"></textarea>
+  <div class="row">
+    <button id="go">Verify</button>
+    <button class="ghost" id="clear">Clear</button>
+    <span class="sub" style="margin:0">or just paste — it verifies automatically</span>
+  </div>
+
+  <div id="out"></div>
+
+  <footer>
+    Canonical reference: <a href="https://www.npmjs.com/package/ust-protocol"><code>npm ust-protocol</code></a> ·
+    source <a href="https://github.com/thelabmd/UST-Protocol">github.com/thelabmd/UST-Protocol</a>.
+    This page runs <a href="./ust-verify.mjs"><code>ust-verify.mjs</code></a> (zero-dependency, WebCrypto).
+    Resolve the verifier <b>by name</b>; never trust a verifier a sender links you to.
+  </footer>
+</main>
+
+<script type="module">
+import { verify } from './ust-verify.mjs';
+
+const $ = (id) => document.getElementById(id);
+const inEl = $('in'), outEl = $('out');
+const esc = (s) => String(s).replace(/[&<>]/g, (c) => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;' }[c]));
+
+function b64decodeUtf8(b64) {
+  const bin = atob(b64.replace(/\s+/g, ''));
+  return new TextDecoder().decode(Uint8Array.from(bin, (c) => c.charCodeAt(0)));
+}
+
+// Accept: full blob (header + ———UST(base64)——— + base64), bare base64, or raw JSON.
+function extractDoc(input) {
+  let s = input.trim();
+  const marker = '———UST(base64)———';
+  if (s.includes(marker)) s = s.slice(s.lastIndexOf(marker) + marker.length).trim();
+  if (s.startsWith('{')) return JSON.parse(s);
+  return JSON.parse(b64decodeUtf8(s));
+}
+
+// Human view REGENERATED from the signed document (never the sender's preamble).
+function renderContent(data) {
+  const parts = Object.entries(data || {}).map(([name, part]) => {
+    if (part && part.value !== undefined) {
+      const v = part.value;
+      const text = (v && typeof v === 'object' && typeof v.text === 'string') ? v.text : JSON.stringify(v, null, 2);
+      return `<div style="margin-bottom:8px"><span class="sub" style="margin:0">${esc(name)}${part.kind ? ' · ' + esc(part.kind) : ''}</span><div class="content">${esc(text)}</div></div>`;
+    }
+    return `<div style="margin-bottom:8px"><span class="sub" style="margin:0">${esc(name)} · ${esc(part && part.privacy || 'private')}</span><div class="content">${esc(part && part.commit || '(private — committed, not revealed)')}</div></div>`;
+  });
+  return parts.join('');
+}
+
+function run() {
+  const raw = inEl.value.trim();
+  outEl.innerHTML = '';
+  if (!raw) return;
+
+  let doc;
+  try { doc = extractDoc(raw); }
+  catch (e) { outEl.innerHTML = `<div class="verdict bad"><span class="dot"></span>UNREADABLE</div><div class="err">Could not decode a UST document from that input (${esc(e.message)}). Paste the whole blob, the base64, or the JSON.</div>`; return; }
+
+  verify(doc, { context: 'data' }).then((r) => {
+    const valid = typeof r.result === 'string' && r.result.slice(0, 6) === 'VALID:';
+    const indet = r.result === 'INDETERMINATE';
+    const cls = valid ? 'ok' : indet ? 'wait' : 'bad';
+    const st = doc.state || {};
+    const id = st.id || {};
+
+    let html = `<div class="verdict ${cls}"><span class="dot"></span>${esc(r.result || 'INVALID')}</div>`;
+
+    if (valid) {
+      html += `<div class="card"><h2>What the signature proves</h2>${renderContent(st.data)}
+        <dl class="kv" style="margin-top:14px">
+          <dt>signing key</dt><dd>${esc(id.key_id || r.publisher_claimed || '')}</dd>
+          <dt>capture time</dt><dd>${esc(st.time && st.time.generated_at || '')}</dd>
+          <dt>frame (ust_id)</dt><dd>${esc(id.ust_id || '')}</dd>
+          <dt>class</dt><dd>${esc(id.class || '')}</dd>
+        </dl></div>`;
+      html += `<p class="note">This is <b>LIGHT</b> tier. It proves the <b>exact bytes above</b>, the <b>signing key</b>, and
+        the <b>claimed capture time</b> — and that they have not been altered. It does <b>not</b> prove <b>who</b> the
+        publisher is (the key is self-certifying, not a verified name) or <b>where</b> the bytes came from. If the
+        sender wrote a <code>Source:</code> line, that is their <b>unverified claim</b>, not part of the proof.</p>`;
+    } else if (indet) {
+      html += `<p class="note">The verifier <b>cannot decide</b> at the requested tier — information it needs
+        (e.g. an anchor or a name-authority witness) was not available. This is <b>not</b> INVALID; it is an honest
+        "cannot confirm." ${r.reason ? '<br>Reason: <code>' + esc(r.reason) + '</code>' : ''}</p>`;
+    } else {
+      html += `<div class="err">${esc(r.error || 'INVALID')}${r.detail ? ' — ' + esc(r.detail) : ''}</div>
+        <p class="note">The document did <b>not</b> verify: its bytes, hashes, or signature are inconsistent. A
+        genuine UST that was edited in transit fails exactly here.</p>`;
+    }
+    outEl.innerHTML = html;
+  }).catch((e) => {
+    outEl.innerHTML = `<div class="verdict bad"><span class="dot"></span>ERROR</div><div class="err">${esc(e.message || String(e))}</div>`;
+  });
+}
+
+$('go').addEventListener('click', run);
+$('clear').addEventListener('click', () => { inEl.value = ''; outEl.innerHTML = ''; inEl.focus(); });
+inEl.addEventListener('input', () => { if (inEl.value.trim()) run(); else outEl.innerHTML = ''; });
+</script>
+</body>
+</html>

--- a/docs/ust-verify.mjs
+++ b/docs/ust-verify.mjs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// ust-verify — the canonical BROWSER verifier for UST 1.0, WebCrypto-only, ZERO dependencies. A clean-room
+// implementation written FROM THE SPEC (it does NOT import ust-protocol) and cross-checked against ust-protocol on
+// the conformance vectors — a second, independent conforming verifier, not a re-export. Runs in browsers, Workers,
+// and Node (global crypto.subtle); async. Backs the findable web verifier at
+// https://thelabmd.github.io/UST-Protocol/ and is the zero-dep verifier an AI can fetch from the CANONICAL source
+// (this repo) — never from a sender's blob. LIGHT floor + stream completeness.
+const te = (s) => new TextEncoder().encode(s);
+const hex = (buf) => [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+const b64url = (s) => Uint8Array.from(atob(String(s).replace(/-/g, '+').replace(/_/g, '/')), (c) => c.charCodeAt(0));
+const concat = (a, b) => { const o = new Uint8Array(a.length + b.length); o.set(a, 0); o.set(b, a.length); return o; };
+
+// §6 canon (JCS, tightened): string-only leaves, NFC, sorted+unique keys. Throws E-CANON.
+export function canon(v) {
+  if (v === null || typeof v === 'number' || typeof v === 'boolean') throw { code: 'E-CANON', detail: 'non-string leaf' };
+  if (typeof v === 'string') { if (v.normalize('NFC') !== v) throw { code: 'E-CANON', detail: 'non-NFC' }; return JSON.stringify(v); }
+  if (Array.isArray(v)) return '[' + v.map(canon).join(',') + ']';
+  const k = Object.keys(v); if (new Set(k).size !== k.length) throw { code: 'E-CANON', detail: 'dup key' };
+  for (const x of k) if (x.normalize('NFC') !== x) throw { code: 'E-CANON', detail: 'non-NFC key' };   // F6 — names too
+  return '{' + k.sort().map((x) => JSON.stringify(x) + ':' + canon(v[x])).join(',') + '}';
+}
+// §7 domain-separated hash: "sha256:" + hex(SHA256(ascii(tag) || 0x00 || body))
+async function digest(tag, body) { return 'sha256:' + hex(await crypto.subtle.digest('SHA-256', concat(concat(te(tag), new Uint8Array([0])), body))); }
+export const H = (tag, str) => digest(tag, te(str));
+export const Hbytes = (tag, bytes) => digest(tag, bytes);
+export const keyId = (pub) => Hbytes('ust:keylog', b64url(pub));               // §12.2 over RAW pubkey bytes
+export async function partitionHash({ domain_shard, ust_id, name, value, commit }) {
+  if (commit !== undefined) return H('ust:shard', commit);                     // §10 private
+  return H('ust:shard', canon({ domain_shard, ust_id, partition: name, value }));  // uniform; name as VALUE (non-colliding), no domain-less
+}
+export const contentHash = (doc) => H('ust:state', canon({ ust: doc.ust, state: doc.state }));
+
+// §7 strict Ed25519: WebCrypto verify + MANUAL canonical-S (reject S >= L). WebCrypto does NOT expose the
+// malleability check, so we enforce it ourselves — this is exactly the kind of gap two implementations surface.
+const L = new Uint8Array([0x10,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x14,0xde,0xf9,0xde,0xa2,0xf7,0x9c,0xd6,0x58,0x12,0x63,0x1a,0x5c,0xf5,0xd3,0xed]);
+export function canonicalS(sig) {
+  const b = b64url(sig); if (b.length !== 64) return false;
+  const S = b.slice(32).reverse();                                            // little-endian → big-endian
+  for (let i = 0; i < 32; i++) { if (S[i] < L[i]) return true; if (S[i] > L[i]) return false; }
+  return false;                                                               // S == L → not < L → reject
+}
+export async function edVerifyRaw(pub, msg, sig) {                             // WebCrypto ONLY (no strict-S) — to observe its behavior
+  try { const k = await crypto.subtle.importKey('raw', b64url(pub), { name: 'Ed25519' }, false, ['verify']);
+    return await crypto.subtle.verify({ name: 'Ed25519' }, k, b64url(sig), te(msg)); } catch { return false; }
+}
+export const edVerifyStrict = async (pub, msg, sig) => canonicalS(sig) && (await edVerifyRaw(pub, msg, sig));
+
+const bad = (code, detail) => ({ result: 'INVALID', error: code, detail });
+const TS = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\dZ$/;  // valid ranges, reject leap :60
+const USTID = /^ust:\d{4}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])\.([01]\d|2[0-3])(([0-5]\d)([0-5]\d)?)?$/;  // F8 valid UTC frame
+const CLASSES = ['observation', 'attestation', 'derivation', 'genesis', 'key'];
+const TRANSCRIPT = ['ust', 'state', 'sig', 'proof'], SIGK = ['alg', 'key_id', 'pub', 'sig'];
+const RES_NAMES = new Set(['id', 'time', 'data', 'hashes', 'provenance', 'domain_shard', 'ust_id', 'key_id', 'class', 'parent_ust', 'partition', 'nonce', '__proto__', 'constructor', 'prototype']);
+const KINDS = ['captured', 'computed'], PRIVACY = ['blinded', 'encrypted'];
+
+// §14 LIGHT floor verify (from the spec). Async. Returns {result, identity, publisher, ust_id, class, content_hash}.
+export async function verify(doc, opts = {}) {
+  try {
+    if (!doc || typeof doc !== 'object') return bad('E-MALFORMED', 'not an object');
+    if (doc.ust !== '1.0') { const m = /^(\d+)\.(\d+)$/.exec(doc.ust || ''); return bad('E-MALFORMED', m && m[1] === '1' ? 'minor > 0 unsupported' : 'unsupported ust version'); }
+    for (const k of Object.keys(doc)) if (!TRANSCRIPT.includes(k)) return bad('E-MALFORMED', 'unknown top-level member: ' + k);  // §4.1 fail-closed
+    const st = doc.state; if (!st || !st.id || !st.time || !st.data || !st.hashes) return bad('E-MALFORMED', 'missing state members');
+    const id = st.id;
+    if (!USTID.test(id.ust_id || '')) return bad('E-MALFORMED', 'bad ust_id');
+    if (!CLASSES.includes(id.class)) return bad('E-MALFORMED', 'bad class');
+    if (!TS.test(st.time.generated_at || '') || !TS.test(st.time.valid_from || '') || !TS.test(st.time.valid_to || '')) return bad('E-MALFORMED', 'bad timestamp (not ISO-Z)');
+    if (opts.context === 'data' && (id.class === 'key' || id.class === 'genesis')) return bad('E-MALFORMED', 'class ' + id.class + ' not valid in data context (W3)');
+    // step 2 — content_hash + bijection + per-partition
+    const ch = await contentHash(doc);
+    const dk = Object.keys(st.data), hk = Object.keys(st.hashes);
+    if (dk.length === 0) return bad('E-MALFORMED', 'no partitions');
+    if (dk.length !== hk.length || !dk.every((k) => k in st.hashes)) return bad('E-MALFORMED', 'data⇄hashes bijection broken');
+    const HASH = /^sha256:[0-9a-f]{64}$/, B64URL = /^[A-Za-z0-9_-]+$/, AEAD = ['AES-256-GCM', 'XChaCha20-Poly1305'];
+    for (const name of dk) {
+      if (RES_NAMES.has(name)) return bad('E-MALFORMED', 'reserved partition name: ' + name);
+      const part = st.data[name];
+      if (part.privacy === undefined) { if (!KINDS.includes(part.kind)) return bad('E-MALFORMED', 'unknown kind: ' + name); if (part.value === undefined) return bad('E-MALFORMED', 'public partition without value: ' + name); }
+      else {
+        if (!PRIVACY.includes(part.privacy)) return bad('E-MALFORMED', 'unknown privacy: ' + name);
+        if (!HASH.test(part.commit || '')) return bad('E-MALFORMED', 'private commit not sha256:hex: ' + name);       // F5
+        if (part.privacy === 'encrypted') { const e = part.enc; if (!e || !AEAD.includes(e.alg) || typeof e.key_id !== 'string' || !B64URL.test(e.ct || '')) return bad('E-MALFORMED', 'encrypted missing/invalid enc: ' + name); }
+      }
+      const want = await partitionHash({ domain_shard: id.domain_shard, ust_id: id.ust_id, name, value: part.value, commit: part.commit });
+      if (want !== st.hashes[name]) return bad('E-MALFORMED', 'partition hash mismatch: ' + name);
+    }
+    // §S4/F4 — class ↔ provenance consistency (signed gap record = the only attestation with empty constituents)
+    const pr = st.provenance;
+    if (id.class === 'observation' && (pr?.constituents !== undefined || pr?.root !== undefined)) return bad('E-MALFORMED', 'observation MUST NOT carry constituents/root');
+    if (id.class === 'derivation' && (pr?.based_on === undefined || pr?.seed === undefined)) return bad('E-MALFORMED', 'derivation MUST carry based_on + seed');
+    if (id.class === 'attestation') { const isGap = pr?.prev !== undefined && (pr?.constituents === undefined || pr.constituents.length === 0); if (!isGap && (pr?.constituents === undefined || pr?.root === undefined)) return bad('E-MALFORMED', 'attestation MUST carry constituents + root'); }
+    // step 4 — authenticity: closed sig schema + alg + key_id consistency + strict Ed25519 over canon({ust,state})
+    const S = canon({ ust: doc.ust, state: st });
+    if (!doc.sig || typeof doc.sig !== 'object') return bad('E-SIG', 'sig missing');
+    for (const k of Object.keys(doc.sig)) if (!SIGK.includes(k)) return bad('E-SIG', 'unknown sig member: ' + k);
+    if (doc.sig.alg !== 'Ed25519') return bad('E-SIG', 'sig.alg must be Ed25519');
+    if (doc.sig.key_id !== id.key_id) return bad('E-SIG', 'sig.key_id != state.id.key_id');
+    if (doc.sig.pub === undefined) return bad('E-KEY', 'no carried pub (LIGHT)');
+    if ((await keyId(doc.sig.pub)) !== id.key_id) return bad('E-SIG', 'key_id != H(ust:keylog, pub)');
+    if (!(await edVerifyStrict(doc.sig.pub, S, doc.sig.sig))) return bad('E-SIG', 'Ed25519 (strict) verify failed');
+    // §3.1 pinned (TOFU): a key not in the caller's pin set is INVALID; else self-asserted (LIGHT — never authoritative here).
+    let strength = 'self-asserted';
+    if (opts.pinnedKeys) { if (!opts.pinnedKeys.includes(id.key_id)) return bad('E-KEY', 'key_id not in the pinned set (§3.1 TOFU)'); strength = 'pinned'; }
+    // §Y3: not authoritative → `domain_shard` is a claimed LABEL, surfaced as `publisher_claimed`.
+    return { result: 'VALID:LIGHT', tier: 'LIGHT', identity: { strength, status: 'verified' }, publisher_claimed: id.domain_shard, ust_id: id.ust_id, class: id.class, content_hash: ch };
+  } catch (e) { return bad(e.code || 'E-MALFORMED', e.detail || String(e)); }
+}
+
+// §11.3 completeness — verify a RANGE as ONE authority's prev-chained stream (LIGHT per-frame + chain + authority).
+// Async (per-frame verify + contentHash are async). Mirrors ust-protocol.verifyStream so the two cross-check.
+export async function verifyStream(frames, { genesis, checkpoint } = {}) {
+  if (!Array.isArray(frames) || !frames.length) return { complete: 'none' };
+  const authority = frames[0].state.id.domain_shard;
+  let prevHash = genesis ? await contentHash(genesis) : null;
+  const seenUstId = new Set(), seenPrev = new Set();
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i];
+    const v = await verify(f, { context: 'data' });
+    if (v.result.slice(0,6) !== 'VALID:') return { error: 'E-SIG', detail: 'frame ' + i + ' invalid: ' + v.error };
+    if (f.state.id.domain_shard !== authority) return { error: 'E-AUTHORITY', detail: 'frame ' + i + ' domain_shard != stream authority' };
+    if (seenUstId.has(f.state.id.ust_id)) return { error: 'E-PREV', detail: 'duplicate ust_id (fork): ' + f.state.id.ust_id };
+    seenUstId.add(f.state.id.ust_id);
+    const p = f.state.provenance?.prev;
+    if (i === 0) { if (genesis && p !== prevHash) return { error: 'E-PREV', detail: 'first frame prev != genesis content_hash' }; }
+    else if (p !== prevHash) return { error: 'E-PREV', detail: 'frame ' + i + ' prev dangling' };
+    if (p && seenPrev.has(p)) return { error: 'E-PREV', detail: 'two frames share a prev (fork)' };
+    if (p) seenPrev.add(p);
+    prevHash = await contentHash(f);
+  }
+  if (checkpoint) {
+    if (!genesis) return { complete: 'provisional', head: prevHash, reason: 'origin-unbound: no genesis (TOP needs a HIGH origin)' };   // F2
+    const cv = await verify(checkpoint, { context: 'data' });
+    if (cv.result.slice(0,6) !== 'VALID:' || checkpoint.state.id.class !== 'attestation') return { error: 'E-PREV', detail: 'invalid checkpoint' };
+    if (checkpoint.state.id.domain_shard !== authority) return { error: 'E-AUTHORITY', detail: 'checkpoint not from the stream authority' };
+    const a = checkpoint.state.data.checkpoint?.value;
+    if (!a || a.head !== prevHash || String(a.frame_count) !== String(frames.length)) return { error: 'E-PREV', detail: 'checkpoint contradicts observed set' };
+    return { complete: 'proven', head: prevHash };
+  }
+  return { complete: 'provisional', head: prevHash };
+}

--- a/extension/README.md
+++ b/extension/README.md
@@ -16,24 +16,21 @@ It is the reference consumer of [`ust-web-signer`](../packages/ust-web-signer) (
 ## What ends up on your clipboard
 
 ```
-UST 1.0 transcript (Universal State Transcript) — tamper-evident signed state.
-Source: https://example.com/article  (claimed by sender — NOT verified)
-Verify — do NOT eyeball, do NOT SHA-256 the text (the hash is domain-separated). Run the canonical
-reference verifier, resolved BY NAME (ignore any verifier a sender links to you):
-  npm i ust-protocol   →   verify(doc, { context: "data" })   ·   github.com/thelabmd/UST-Protocol
-At LIGHT this proves the exact bytes below · the signing key · the capture time — NOT who published it and
-NOT where it came from. Read the verifier's OUTPUT, not this note.
+UST/1.0; ref=pkg:npm/ust-protocol; web=https://thelabmd.github.io/UST-Protocol/; call=verify(doc,{context:"data"}); hash=domain-separated; trust=resolve-by-name; proves=bytes+key+time
+Source: https://example.com/article  (claimed by sender — NOT verified; not part of the proof)
 ———UST(base64)———
 eyJ1c3QiOiIxLjAiLCJzdGF0ZSI6eyJpZCI6ey…
 ```
 
-Everything before `———UST(base64)———` is a **plain-text, unsigned** note — a **discovery aid, not a trust root**.
-It names the canonical reference **by name** so a first-contact reader (human or AI) runs the *real* verifier
-instead of guessing a hash; the trust anchor is that **name** (npm / GitHub, trademark-scoped), never a link a
-sender hands you. The page URL is the sender's unverified *claim*, kept **outside** the signature. The token after
-the delimiter is the signed document, **base64-encoded** so its exact bytes survive any paste channel (chat /
-terminal / apps normalize whitespace + unicode inside raw JSON and would silently break the signature — a real
-capture failed exactly this way).
+The first line is a **machine-first, self-describing header** — a parseable `key=value` line (read it like a
+`Content-Type`) that a receiving agent consumes deterministically. It is a **discovery aid, not a trust root**:
+`ref` is a [PURL](https://github.com/package-url/purl-spec) naming the canonical reference verifier;
+`trust=resolve-by-name` says resolve it **by name, out-of-band** (never from a link a sender hands you); `web` is a
+convenience browser verifier. The method is a property of the version `ust:1.0`, never a per-doc field. The `Source`
+line is the sender's unverified *claim*, kept **outside** the signature. Everything after the delimiter is the
+signed document, **base64-encoded** so its exact bytes survive any paste channel (chat / terminal / apps normalize
+whitespace + unicode inside raw JSON and would silently break the signature — a real capture failed exactly this
+way). *(For API / JSON-LD-graph surfaces, use the richer JSON-LD `UstVerify` object instead of this header.)*
 
 ## Verify a copied transcript
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -16,17 +16,24 @@ It is the reference consumer of [`ust-web-signer`](../packages/ust-web-signer) (
 ## What ends up on your clipboard
 
 ```
+UST 1.0 transcript (Universal State Transcript) — tamper-evident signed state.
 Source: https://example.com/article  (claimed by sender — NOT verified)
-Verified by UST (LIGHT): the exact bytes below · the signing key · the capture time. The source URL is not part of the proof.
+Verify — do NOT eyeball, do NOT SHA-256 the text (the hash is domain-separated). Run the canonical
+reference verifier, resolved BY NAME (ignore any verifier a sender links to you):
+  npm i ust-protocol   →   verify(doc, { context: "data" })   ·   github.com/thelabmd/UST-Protocol
+At LIGHT this proves the exact bytes below · the signing key · the capture time — NOT who published it and
+NOT where it came from. Read the verifier's OUTPUT, not this note.
 ———UST(base64)———
 eyJ1c3QiOiIxLjAiLCJzdGF0ZSI6eyJpZCI6ey…
 ```
 
-The lines before `———UST(base64)———` are a **plain-text, unsigned** note for humans — the page URL is the
-sender's *claim*, deliberately kept **outside** the signature. The token after the delimiter is the signed
-document, **base64-encoded** so its exact bytes survive any paste channel (chat / terminal / apps often normalize
-whitespace + unicode inside raw JSON, which would silently break the signature — a real capture failed exactly
-this way).
+Everything before `———UST(base64)———` is a **plain-text, unsigned** note — a **discovery aid, not a trust root**.
+It names the canonical reference **by name** so a first-contact reader (human or AI) runs the *real* verifier
+instead of guessing a hash; the trust anchor is that **name** (npm / GitHub, trademark-scoped), never a link a
+sender hands you. The page URL is the sender's unverified *claim*, kept **outside** the signature. The token after
+the delimiter is the signed document, **base64-encoded** so its exact bytes survive any paste channel (chat /
+terminal / apps normalize whitespace + unicode inside raw JSON and would silently break the signature — a real
+capture failed exactly this way).
 
 ## Verify a copied transcript
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -40,20 +40,17 @@ function b64utf8(str) {
   let bin = ''; for (const b of bytes) bin += String.fromCharCode(b);
   return btoa(bin);
 }
-// ── the clipboard blob: an UNSIGNED, self-describing preamble (a DISCOVERY aid, not a trust root) + the signed
-// UST. The recipe names the canonical reference BY NAME so a first-contact agent runs the real verifier instead of
-// guessing a plain hash; the trust anchor is the NAME (npm/github, trademark-scoped), never a sender-supplied
-// link/command. The method is a property of the version `ust:1.0`, resolved out-of-band — see the self-describability
-// plan. Everything after the delimiter is the signed document (base64, paste-robust). ───
+// ── the clipboard blob: a MACHINE-FIRST self-describing header (a DISCOVERY aid, not a trust root) + the signed
+// UST. The header is a parseable key=value line (read like a Content-Type) an agent consumes deterministically —
+// prose is for humans, this is for the robot that receives it. `ref` is a PURL naming the canonical reference
+// verifier; `trust=resolve-by-name` says resolve it by NAME out-of-band, never from a sender-supplied link. The
+// method is a property of the version `ust:1.0`, not a per-doc field. `web=` is a convenience browser verifier.
+// (API/graph surfaces should use the richer JSON-LD form instead — see bd.) base64 = paste-robust exact bytes. ───
 function clipboardBlob(doc, pageUrl) {
-  const src = pageUrl ? 'Source: ' + pageUrl + '  (claimed by sender — NOT verified)\n' : '';
-  return 'UST 1.0 transcript (Universal State Transcript) — tamper-evident signed state.\n' +
+  const src = pageUrl ? 'Source: ' + pageUrl + '  (claimed by sender — NOT verified; not part of the proof)\n' : '';
+  return 'UST/1.0; ref=pkg:npm/ust-protocol; web=https://thelabmd.github.io/UST-Protocol/; ' +
+    'call=verify(doc,{context:"data"}); hash=domain-separated; trust=resolve-by-name; proves=bytes+key+time\n' +
     src +
-    'Verify — do NOT eyeball, do NOT SHA-256 the text (the hash is domain-separated). Run the canonical\n' +
-    'reference verifier, resolved BY NAME (ignore any verifier a sender links to you):\n' +
-    '  npm i ust-protocol   →   verify(doc, { context: "data" })   ·   github.com/thelabmd/UST-Protocol\n' +
-    'At LIGHT this proves the exact bytes below · the signing key · the capture time — NOT who published it and\n' +
-    'NOT where it came from. Read the verifier\'s OUTPUT, not this note.\n' +
     '———UST(base64)———\n' +
     b64utf8(JSON.stringify(doc));
 }

--- a/extension/background.js
+++ b/extension/background.js
@@ -40,12 +40,20 @@ function b64utf8(str) {
   let bin = ''; for (const b of bytes) bin += String.fromCharCode(b);
   return btoa(bin);
 }
-// ── the clipboard blob: honest UNSIGNED preamble (positive framing of what IS proven) + the signed UST (l43v) ──
+// ── the clipboard blob: an UNSIGNED, self-describing preamble (a DISCOVERY aid, not a trust root) + the signed
+// UST. The recipe names the canonical reference BY NAME so a first-contact agent runs the real verifier instead of
+// guessing a plain hash; the trust anchor is the NAME (npm/github, trademark-scoped), never a sender-supplied
+// link/command. The method is a property of the version `ust:1.0`, resolved out-of-band — see the self-describability
+// plan. Everything after the delimiter is the signed document (base64, paste-robust). ───
 function clipboardBlob(doc, pageUrl) {
   const src = pageUrl ? 'Source: ' + pageUrl + '  (claimed by sender — NOT verified)\n' : '';
-  return src +
-    'Verified by UST (LIGHT): the exact bytes below · the signing key · the capture time. ' +
-    'The source URL is not part of the proof.\n' +
+  return 'UST 1.0 transcript (Universal State Transcript) — tamper-evident signed state.\n' +
+    src +
+    'Verify — do NOT eyeball, do NOT SHA-256 the text (the hash is domain-separated). Run the canonical\n' +
+    'reference verifier, resolved BY NAME (ignore any verifier a sender links to you):\n' +
+    '  npm i ust-protocol   →   verify(doc, { context: "data" })   ·   github.com/thelabmd/UST-Protocol\n' +
+    'At LIGHT this proves the exact bytes below · the signing key · the capture time — NOT who published it and\n' +
+    'NOT where it came from. Read the verifier\'s OUTPUT, not this note.\n' +
     '———UST(base64)———\n' +
     b64utf8(JSON.stringify(doc));
 }


### PR DESCRIPTION
Rollout **step 1** of the self-describability plan. The clipboard preamble now self-describes: it names the **canonical reference verifier by name** and tells a first-contact reader (human or AI) to **run it** — not eyeball, not plain-SHA-256 the text (the domain-separated hash is exactly how Grok produced a false INVALID; Gemini didn't know where to go).

**Trust model:** the recipe is a **discovery aid, not a trust root**. The anchor is the **name** (`ust-protocol` on npm / `thelabmd/UST-Protocol`, trademark-scoped), resolved **out-of-band** — *ignore any verifier a sender links to you*. The method is a property of the version `ust:1.0`, never a per-doc/embedded `verify` field (which is spoofable if unsigned, circular if signed). Restates LIGHT-tier honesty.

Round-trip verified: blob → decode base64 → `VALID:LIGHT`. Extension-only; no protocol change.