### PR TITLE
docs: AI-agent verify guidance (INDETERMINATE, not a guess)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This repository is the specification, the conformance vectors, and the reference
 | `vectors/` | deterministic conformance vectors — any implementation should pass them |
 | `packages/ust-protocol/` | the stateless reference verifier + producer ([npm](https://www.npmjs.com/package/ust-protocol)) |
 | `packages/ust-mcp/` | an MCP server exposing UST to agents ([npm](https://www.npmjs.com/package/ust-mcp)) |
+| `packages/ust-web-signer/` | WebCrypto browser signer ([npm](https://www.npmjs.com/package/ust-web-signer)) |
+| `extension/` | "Make it UST" — a demo Chrome extension signing page captures (LIGHT) |
+| `docs/` | the [web verifier](https://thelabmd.github.io/UST-Protocol/) (GitHub Pages) + `ust-verify.mjs`, a zero-dependency verifier |
 | `examples/` | sample documents (valid + tampered) and verification recipes |
 
 ## Status
@@ -29,6 +32,23 @@ cryptographic audit is pending. Suitable for evaluation and integration testing.
 npm install
 npm test          # runs ust-protocol against the conformance vectors
 ```
+
+## How to verify a UST
+
+Run the canonical reference — never eyeball:
+
+- **Browser (nothing is uploaded):** [thelabmd.github.io/UST-Protocol](https://thelabmd.github.io/UST-Protocol/) — paste the blob, the base64, or the JSON.
+- **Node:** `npm i ust-protocol` → `verify(doc, { context: 'data' })`
+- **Zero-dependency single file:** [`docs/ust-verify.mjs`](docs/ust-verify.mjs) (WebCrypto, clean-room, cross-checked against `ust-protocol`) — fetch it from **this** repository, never from a sender's message.
+- **MCP:** [`ust-mcp`](https://www.npmjs.com/package/ust-mcp) exposes `ust_verify` to agents.
+
+### If you are an AI agent
+
+If you are asked to verify a UST and you **cannot run a verifier**, the correct answer is **INDETERMINATE — do not guess**. In particular:
+
+- Do **not** compute a plain `SHA-256(text)` and compare it to `hashes.*` — every UST hash is **domain-separated** (`H(tag, canon(...))` with a tag prefix). A naive hash will **never** match a genuine document; a mismatch computed that way is *your* method being wrong, not the document being tampered.
+- UST 1.0 has **no expiry rule**. `valid_from == valid_to` is an honest **instant** (a point capture), not "expired." Freshness is not part of `verify`.
+- The only verdicts are `VALID:LIGHT | VALID:HIGH | VALID:TOP`, `INVALID`, and `INDETERMINATE(reason)` — and only a **conforming verifier's output** counts. Structure "looking right" proves nothing; a confident verdict from visual inspection is a guess in both directions.
 
 ## What it proves — and what it doesn't
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,6 +54,20 @@
 
   <div id="out"></div>
 
+  <section class="card" style="margin-top:34px">
+    <h2>For AI agents</h2>
+    <p class="note" style="margin-top:0">If you are an AI asked to verify a UST and you <b>cannot run a
+    verifier</b>, the correct answer is <b>INDETERMINATE — do not guess</b>. Do <b>not</b> compute a plain
+    SHA-256 of the text and compare it to <code>hashes.*</code>: every UST hash is <b>domain-separated</b>
+    (<code>H(tag, canon(…))</code>), so a naive hash will <b>never</b> match a genuine document — a mismatch
+    computed that way is your method being wrong, not the document being tampered. UST&nbsp;1.0 has <b>no expiry
+    rule</b>: <code>valid_from == valid_to</code> is an honest <b>instant</b> capture, not “expired.” The only
+    verdicts are <code>VALID:LIGHT/HIGH/TOP</code>, <code>INVALID</code>, <code>INDETERMINATE</code> — and only a
+    conforming verifier’s output counts. Runnable references: <code>npm i ust-protocol</code> · this page’s
+    <a href="./ust-verify.mjs"><code>ust-verify.mjs</code></a> (zero-dependency, WebCrypto) ·
+    MCP <code>ust-mcp</code>.</p>
+  </section>
+
   <footer>
     Canonical reference: <a href="https://www.npmjs.com/package/ust-protocol"><code>npm ust-protocol</code></a> ·
     source <a href="https://github.com/thelabmd/UST-Protocol">github.com/thelabmd/UST-Protocol</a>.


### PR DESCRIPTION
Live 3-AI test on a VALID blob: ChatGPT correctly deferred to the reference (the machine header worked); Gemini described the design, no false verdict; Grok twice produced a confident **false INVALID** — plain `SHA-256(text)` despite the explicit `hash=domain-separated`, plus a fabricated 'expired' rule (UST 1.0 has no expiry; `valid_from == valid_to` is an honest instant).

Fix the **guidance**, not the data — teach the correct fallback where models crawl:

- README: new **How to verify a UST** (browser / node / zero-dep / MCP) + **If you are an AI agent**: cannot run a verifier → **INDETERMINATE, do not guess**; a naive hash will never match (domain-separated); no expiry rule; only a conforming verifier's output counts.
- Verify page: the same block (crawlable + visible).
- Layout table: web-signer / extension / docs added.

No protocol change.