### PR TITLE
feat(extension): 'Verify UST' context menu — the verify gesture mirrors the sign gesture

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -5,8 +5,9 @@ A minimal Manifest V3 extension that packages the **LIGHT tier** of [UST](https:
 into one gesture each way:
 
 - **Sign:** select text → right-click → **"Make it UST"** → a signed transcript is on your clipboard.
-- **Verify:** click the toolbar icon → paste any UST (the whole blob, the base64, or the JSON) → the verdict plus
-  the **real signed content**, verified locally.
+- **Verify:** select a pasted UST anywhere → right-click → **"Verify UST"** → the popup opens with the verdict
+  plus the **real signed content**, verified locally. (Or click the toolbar icon and paste it into the box —
+  same thing.) Chrome collapses newlines in a selection; harmless — the signed bytes ride as base64 armor.
 
 It is the reference consumer of [`ust-web-signer`](../packages/ust-web-signer) (bundled in `lib/`, alongside the
 zero-dependency verifier `ust-verify.mjs`).

--- a/extension/background.js
+++ b/extension/background.js
@@ -6,6 +6,7 @@
 import * as W from './lib/ust-web-signer.mjs';
 
 const MENU_ID = 'make-it-ust';
+const VERIFY_ID = 'verify-ust';
 
 // ── persistent, non-extractable Ed25519 identity in IndexedDB (CryptoKeys are structured-cloneable) ──
 function openDB() {
@@ -75,10 +76,24 @@ async function copyToTab(tabId, text) {
 
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({ id: MENU_ID, title: 'Make it UST', contexts: ['selection'] });
+  chrome.contextMenus.create({ id: VERIFY_ID, title: 'Verify UST', contexts: ['selection'] });
   getSigner();                                             // warm (generate) the identity on install
 });
 
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  // ── Verify UST: select a pasted transcript on any page → the popup opens with the verdict. The selection is
+  // handed to the popup via storage.session (never rendered by the page). Chrome collapses newlines in
+  // selectionText — harmless BY DESIGN: the signed document rides as base64 (ASCII armor), so whitespace mangling
+  // in the wrapper can't touch the bytes. Verification itself happens in the popup, from the signed bytes. ──
+  if (info.menuItemId === VERIFY_ID) {
+    if (!info.selectionText) return;
+    await chrome.storage.session.set({ pendingVerify: info.selectionText });
+    try { await chrome.action.openPopup(); }               // user gesture from the menu click (Chrome 127+)
+    catch {                                                // older Chrome: badge-hint; the popup picks it up when opened
+      if (tab?.id) { chrome.action.setBadgeText({ text: 'UST', tabId: tab.id }); chrome.action.setBadgeBackgroundColor({ color: '#8a6d00', tabId: tab.id }); }
+    }
+    return;
+  }
   if (info.menuItemId !== MENU_ID || !info.selectionText || !tab?.id) return;
   try {
     const signer = await getSigner();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Make it UST",
   "version": "0.1.0",
-  "description": "Sign selected text as a UST (Universal State Transcript). LIGHT tier: proves the exact bytes, your key, and the time — not who you are or where it came from.",
-  "permissions": ["contextMenus", "scripting", "activeTab"],
+  "description": "Sign selected text as a UST (Universal State Transcript) — and verify any UST locally. LIGHT tier: proves the exact bytes, your key, and the time — not who you are or where it came from.",
+  "permissions": ["contextMenus", "scripting", "activeTab", "storage"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": { "default_popup": "popup.html", "default_title": "Make it UST" }
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -83,3 +83,16 @@ async function runVerify() {
   }
 }
 vin.addEventListener('input', runVerify);
+
+// ── "Verify UST" context menu handoff: the selection arrives via storage.session — fill the box and verify. ──
+(async () => {
+  try {
+    const { pendingVerify } = await chrome.storage.session.get('pendingVerify');
+    if (pendingVerify) {
+      await chrome.storage.session.remove('pendingVerify');
+      chrome.action.setBadgeText({ text: '' });            // clear the fallback badge, if any
+      vin.value = pendingVerify;
+      runVerify();
+    }
+  } catch { /* storage unavailable (e.g. opened as a plain page) — paste still works */ }
+})();


### PR DESCRIPTION
Select a pasted UST anywhere → right-click → **Verify UST** → the popup opens with the verdict + the content regenerated from the signed bytes. Handoff via `storage.session`; `chrome.action.openPopup()` on the menu gesture (Chrome 127+), badge-hint fallback older. Paste-in-popup still works.

Chrome collapses newlines in `selectionText` — harmless **by design**: the signed document rides as base64 armor, wrapper whitespace mangling can't touch the bytes. Tested: newline-collapsed blob → `VALID:LIGHT`; bare base64 → `VALID:LIGHT`.

`+storage` permission (session handoff). No protocol change.