### PR TITLE
fix: pre-audit consistency sweep — one repo, one moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ This repository is the specification, the conformance vectors, and the reference
 
 ## Status
 
-Release candidate — **`1.0.0-rc.1`**. The specification has been extensively red-teamed; an independent external
-cryptographic audit is pending. Suitable for evaluation and integration testing. Pin exact versions.
+Release candidate — the specification is at **`1.0.0-rc.5`** (each package pins its own rc on npm). Extensively
+red-teamed; four external AI reviews folded in (see the spec changelog); an independent human cryptographic audit
+is pending. Suitable for evaluation and integration testing. Pin exact versions.
 
 ## Quickstart
 

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,4 +1,4 @@
-# UST 1.0.0-rc.4 — External Audit Brief
+# UST 1.0.0-rc.5 — External Audit Brief
 
 _For an independent cryptographic-protocol reviewer._
 
@@ -36,12 +36,14 @@ We have already done extensive **self**-review (§6). We are buying the thing se
 
 ```
 npm     npm i ust-protocol@rc          # the reference verifier + producer (Apache-2.0, zero-dep, node:crypto)
-        npx -y ust-mcp@rc              # the MCP server (8 tools)
-git     github.com/thelabmd/UST        # monorepo — everything below in one clone
+        npx -y ust-mcp@rc              # the MCP server (9 tools)
+        npm i ust-web-signer@rc        # the WebCrypto browser signer (producer side)
+git     github.com/thelabmd/UST-Protocol   # monorepo — everything below in one clone
           spec/UST-1.0.md              # the normative specification (this is the source of truth)
-          vectors/conformance-vectors.json   # deterministic test vectors (36)
+          vectors/conformance-vectors.json   # deterministic test vectors (26; the runner adds behavioral checks — 56 total)
           packages/ust-protocol/       # reference impl + its conformance runner
           examples/                    # sample docs (valid + tampered) + verify recipes
+web     thelabmd.github.io/UST-Protocol # in-browser verifier (client-side) + llms.txt (machine instructions)
 ```
 On request (kept out of the public repo): the **second, clean-room implementation** (`ust-verify-web`, WebCrypto,
 written from the spec without importing `ust-protocol`) and the **red-team dossier** (the six passes below, in full).
@@ -49,7 +51,7 @@ written from the spec without importing `ust-protocol`) and the **red-team dossi
 ## 4. How to test
 
 ```
-git clone github.com/thelabmd/UST && cd UST && npm install
+git clone github.com/thelabmd/UST-Protocol && cd UST-Protocol && npm install
 npm test                               # runs ust-protocol against all conformance vectors
 ```
 - **Cross-examine two implementations.** Run `ust-protocol` and the clean-room `ust-verify-web` against the same
@@ -115,7 +117,8 @@ each and, more importantly, find a **seventh** we didn't think of.
   revocation, I14 bounded verification (depth-0 default).
 - **Outcome vocabulary (E-codes):** E-MALFORMED, E-CANON, E-SIG, E-KEY, E-COMMIT, E-ROOT, E-PREV, E-GENESIS,
   E-AUTHORITY, E-ANCHOR, E-BOUNDS, E-CYCLE, E-BINDING, E-MODEL. Verification is fail-closed and returns one of
-  three verdicts: **VALID / INVALID / INDETERMINATE** (availability is never confused with failure).
+  three outcomes: **VALID:LIGHT | VALID:HIGH | VALID:TOP / INVALID / INDETERMINATE** — the verdict CARRIES its
+  tier; a bare `VALID` is never emitted (availability is never confused with failure).
 - The six red-team passes + the v0.29 passes are available in full (with every finding and how it was closed
   STRUCTURALLY) so you can judge the fixes rather than re-derive the findings.
 
@@ -136,10 +139,10 @@ residual risk, and what would you require before a `1.0.0` final tag?
 ## 9. What we have already done (so you go deeper, not sideways)
 
 - **Six adversarial red-team passes** on the v1.0 final form + four on the v0.29 predecessor — all self-review.
-- **36 deterministic conformance vectors**, and the reference impl passes them (one known note: duplicate-key
+- **26 deterministic conformance vectors** plus a behavioral conformance runner (56 checks total), and the reference impl passes them (one known note: duplicate-key
   rejection needs a raw-bytes JSON parser — `JSON.parse` collapses dups — a harness limitation, not an impl flaw).
 - **Two independent implementations** (`ust-protocol` node + `ust-verify-web` clean-room WebCrypto) cross-checked: **32/32 agree, 0 divergence**.
-- **rc.2 review round complete:** four preliminary reviews (ChatGPT code + Gemini spec + Gemini 3.1 architecture + ChatGPT 5.5 Max adversarial) produced the changes; all folded in (details in the on-request `FINDINGS-rc1-to-rc2.md`).
+- **Four external AI reviews folded in (rc.1 → rc.5):** ChatGPT code + Gemini spec + Gemini 3.1 architecture + ChatGPT 5.5 Max adversarial (details in the on-request `FINDINGS-rc1-to-rc5.md`).
 - **Honest disclosure:** all of the above is one team's work → correlated blind spots. That is precisely the gap
   an external adversarial review closes. Please assume the design is wrong somewhere and find it.
 ```

--- a/examples/ust-verify-recipe.md
+++ b/examples/ust-verify-recipe.md
@@ -65,19 +65,20 @@ the tag from the input (domain separation). `x` is UTF-8 bytes for a string, or 
    NOT plain SHA-256(pub) and NOT the base64url string. It MUST equal BOTH `sig.key_id` and `state.id.key_id`.
    *(Note: `key_id` is NOT plain `SHA256(pub)` — it is domain-separated with the `ust:keylog` tag and a 0x00 byte.)*
 
-`VALID` iff steps 3–7 all pass.
+`VALID:LIGHT` iff steps 3–7 all pass. (The verdict **carries its tier** — `VALID:LIGHT | VALID:HIGH | VALID:TOP`;
+a conforming verifier never emits a bare `VALID`.)
 
 ## Expected result
 
 ```
 content_hash = sha256:5b5bd6d116af15c90b3cfd90aadc4c5477d6bd3f0d8e3057c464d93e08e0e4de
 key_id       = sha256:8d506c06ffdab38f3b4663c189801cc7f516c801af9f06a0ee65fd7cf42b3af7   (= H("ust:keylog", raw_pubkey_bytes), matches sig.key_id & id.key_id)
-signature    = VALID
+signature    = verifies   →  document verdict: VALID:LIGHT
 ```
 
 Change any character in `state` (e.g. `kp` 4.33 → 9.99) and the signature FAILS — the bytes are tamper-evident.
 
-## What a VALID result means (and does not)
+## What a VALID:LIGHT result means (and does not)
 
 - **Means:** the holder of this key signed **exactly these bytes** — this observation, for `ust:20260628.14`,
   sealed at `generated_at`. Integrity + who-key + key_id-consistency: proven, offline.

--- a/packages/ust-mcp/README.md
+++ b/packages/ust-mcp/README.md
@@ -6,8 +6,9 @@
 [Model Context Protocol](https://modelcontextprotocol.io) tools, so any MCP-capable agent can check that a piece
 of state is what it claims — who published it, when, unchanged — without trusting whoever served the bytes.
 
-> **Release candidate — `1.0.0-rc.1`.** The specification has been extensively red-teamed; an independent
-> external cryptographic audit is pending. Suitable for evaluation. Pin exact versions.
+> **Release candidate.** The specification is at `1.0.0-rc.5`; this package pins its own rc on npm. Extensively
+> red-teamed; four external AI reviews folded in; an independent human cryptographic audit is pending. Suitable
+> for evaluation. Pin exact versions.
 
 ## Run
 
@@ -62,7 +63,7 @@ the root on-chain.
 This is the **protocol MCP** — universal, publisher-agnostic. A separate **product MCP** (pricing, receipts,
 archive depth) is operated by publishers such as noosphere; the two are never mixed.
 
-Depends on [`ust-protocol`](https://www.npmjs.com/package/ust-protocol). Spec: **https://github.com/thelabmd/UST/blob/main/spec/UST-1.0.md**
+Depends on [`ust-protocol`](https://www.npmjs.com/package/ust-protocol). Spec: **https://github.com/thelabmd/UST-Protocol/blob/main/spec/UST-1.0.md**
 
 ## License
 

--- a/packages/ust-mcp/package.json
+++ b/packages/ust-mcp/package.json
@@ -39,5 +39,5 @@
     "directory": "packages/ust-mcp"
   },
   "homepage": "https://github.com/thelabmd/UST-Protocol/tree/main/packages/ust-mcp#readme",
-  "bugs": "https://github.com/thelabmd/UST/issues"
+  "bugs": "https://github.com/thelabmd/UST-Protocol/issues"
 }

--- a/packages/ust-protocol/README.md
+++ b/packages/ust-protocol/README.md
@@ -11,8 +11,9 @@ travels *with* the data.
 verification, privacy commitments, chains, and anchoring. Zero-dependency (`node:crypto`; a WebCrypto/`@noble`
 adapter for browsers and Workers — same rules, same results).
 
-> **Release candidate — `1.0.0-rc.1`.** The specification has been extensively red-teamed; an independent
-> external cryptographic audit is pending. Suitable for evaluation and integration testing. Pin exact versions.
+> **Release candidate.** The specification is at `1.0.0-rc.5`; this package pins its own rc on npm. Extensively
+> red-teamed; four external AI reviews folded in; an independent human cryptographic audit is pending. Suitable
+> for evaluation and integration testing. Pin exact versions.
 
 ## Install
 
@@ -85,7 +86,7 @@ confused with failure.
 
 ## Spec & conformance
 
-- Specification and a client-side verifier: **https://github.com/thelabmd/UST/blob/main/spec/UST-1.0.md**
+- Specification and a client-side verifier: **https://github.com/thelabmd/UST-Protocol/blob/main/spec/UST-1.0.md**
 - This library is validated against a suite of deterministic conformance vectors (the same vectors any
   independent implementation should pass).
 

--- a/packages/ust-protocol/package.json
+++ b/packages/ust-protocol/package.json
@@ -36,5 +36,5 @@
     "directory": "packages/ust-protocol"
   },
   "homepage": "https://github.com/thelabmd/UST-Protocol/tree/main/packages/ust-protocol#readme",
-  "bugs": "https://github.com/thelabmd/UST/issues"
+  "bugs": "https://github.com/thelabmd/UST-Protocol/issues"
 }

--- a/packages/ust-web-signer/README.md
+++ b/packages/ust-web-signer/README.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # ust-web-signer
 
-The **browser-side signer** for [UST (Universal State Transcript)](https://github.com/thelabmd/UST). It is the
+The **browser-side signer** for [UST (Universal State Transcript)](https://github.com/thelabmd/UST-Protocol). It is the
 one piece [`ust-protocol`](https://www.npmjs.com/package/ust-protocol) deliberately leaves out: a **private key
 never enters the verifier library**. This package generates an Ed25519 key with WebCrypto, signs, and produces the
 full `{ ust, state, sig }` document. Its `canon`/hash/preimage code is byte-identical to `ust-protocol`, so what

--- a/packages/ust-web-signer/package.json
+++ b/packages/ust-web-signer/package.json
@@ -31,5 +31,5 @@
     "directory": "packages/ust-web-signer"
   },
   "homepage": "https://github.com/thelabmd/UST-Protocol/tree/main/packages/ust-web-signer#readme",
-  "bugs": "https://github.com/thelabmd/UST/issues"
+  "bugs": "https://github.com/thelabmd/UST-Protocol/issues"
 }

--- a/vectors/conformance-vectors.json
+++ b/vectors/conformance-vectors.json
@@ -1,6 +1,6 @@
 {
   "version": "UST 1.0 conformance vectors (rc.2 — uniform preimage, no domain-less computed)",
-  "note": "Deterministic + reproducible. Keypairs from fixed seeds (A=0011..eeff, B=ffee..1100). canon=JCS tightened; H(tag,x)=sha256(ascii(tag)||0x00||x); content_hash=H(\"ust:state\",canon({ust,state})); key_id=H(\"ust:keylog\",raw_pub); partition_hash=H(\"ust:shard\",canon({domain_shard,ust_id,partition,value})) — UNIFORM, every partition binds domain_shard, name is a VALUE (non-colliding), no domain-less computed. Each vector states the SPEC rule it pins.",
+  "note": "Deterministic + reproducible. Keypairs from fixed seeds (A=0011..eeff, B=ffee..1100). canon=JCS tightened; H(tag,x)=sha256(ascii(tag)||0x00||x); content_hash=H(\"ust:state\",canon({ust,state})); key_id=H(\"ust:keylog\",raw_pub); partition_hash=H(\"ust:shard\",canon({domain_shard,ust_id,partition,value})) — UNIFORM, every partition binds domain_shard, name is a VALUE (non-colliding), no domain-less computed. Each vector states the SPEC rule it pins. Signature-type vectors use expect: 'VALID' | 'E-SIG' for the Ed25519 PRIMITIVE check (strict, canonical-S); this is not a document verdict — a conforming verifier's document verdict is always tier-qualified (VALID:LIGHT/HIGH/TOP), never a bare VALID. Partition names inside hash/commit inputs (e.g. 'secret') are arbitrary sample names, not protocol features.",
   "seeds": {
     "A": "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
     "B": "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"


### PR DESCRIPTION
Mass consistency pass before the external professional audit: every document now reflects a single real moment (spec rc.5 · packages rc.5/rc.7/rc.2 · 9 MCP tools · 26 vectors + 56-check runner · UST-Protocol repo name).

Fixed: stale rc.1 status lines ×3 · docs/AUDIT.md rc.4-era facts (public Pages page) · old repo URLs ×8 · bare VALID in examples recipe and AUDIT.md · vectors `expect` semantics documented (primitive check ≠ document verdict; vector data untouched — it's the contract).

Historical changelog lines left as history (the rc.4 entry records the tier-verdict transition explicitly).

Tests: `npm test` 56/0 · web-signer 7/0. No protocol change.